### PR TITLE
django 1.3 django.contrib.staticfiles support

### DIFF
--- a/compress/conf/settings.py
+++ b/compress/conf/settings.py
@@ -1,6 +1,10 @@
 from django.core.exceptions import ImproperlyConfigured
 from django.conf import settings
 
+
+COMPRESS_ROOT = getattr(settings, 'COMPRESS_ROOT', settings.MEDIA_ROOT)
+COMPRESS_URL = getattr(settings, 'COMPRESS_URL', settings.MEDIA_URL)
+
 COMPRESS = getattr(settings, 'COMPRESS', not settings.DEBUG)
 COMPRESS_AUTO = getattr(settings, 'COMPRESS_AUTO', True)
 COMPRESS_VERSION = getattr(settings, 'COMPRESS_VERSION', False)

--- a/compress/utils.py
+++ b/compress/utils.py
@@ -56,14 +56,14 @@ def needs_update(output_file, source_files, verbosity=0):
 
 def media_root(filename):
     """
-    Return the full path to ``filename``. ``filename`` is a relative path name in MEDIA_ROOT
+    Return the full path to ``filename``. ``filename`` is a relative path name in COMPRESS_ROOT
     """
-    return os.path.join(django_settings.MEDIA_ROOT, filename)
+    return os.path.join(settings.COMPRESS_ROOT, filename)
 
 def media_url(url, prefix=None):
     if prefix:
         return prefix + urlquote(url)
-    return django_settings.MEDIA_URL + urlquote(url)
+    return settings.COMPRESS_URL + urlquote(url)
 
 def concat(filenames, separator=''):
     """


### PR DESCRIPTION
added two new settings - COMPRESS_ROOT and COMPRESS_URL which point by default to MEDIA_ROOT and MEDIA_URL respectively. That settings make ability to use both django 1.3 django.contrib.staticfiles and django-compress without incompatible issues
